### PR TITLE
Use next/image components and configure image domains

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ import {
   ArrowRight,
 } from "lucide-react"
 import Link from "next/link"
+import Image from "next/image"
 import { useState, useEffect } from "react"
 
 export default function WindoorHomepage() {
@@ -108,7 +109,13 @@ export default function WindoorHomepage() {
           <div className="relative group">
             <div className="bg-slate-800 shadow-lg rounded-lg px-3 py-2 border border-slate-600 hover:shadow-xl transition-all duration-300 cursor-pointer">
               <div className="flex items-center space-x-2">
-                <img src="/images/dcasas-logo.png" alt="D-CASAS" className="h-5 w-auto brightness-0 invert" />
+                <Image
+                  src="/images/dcasas-logo.png"
+                  alt="D-CASAS"
+                  width={100}
+                  height={20}
+                  className="h-5 w-auto brightness-0 invert"
+                />
                 <div className="text-center">
                   <div className="text-xs font-medium text-white">Partner</div>
                   <div className="text-[10px] text-slate-300 leading-tight">
@@ -124,9 +131,11 @@ export default function WindoorHomepage() {
               <div className="bg-slate-800 shadow-2xl rounded-xl border border-slate-600 overflow-hidden">
                 <div className="p-4">
                   <div className="flex items-start space-x-3">
-                    <img
+                    <Image
                       src="/images/dcasas-logo.png"
                       alt="D-CASAS"
+                      width={160}
+                      height={32}
                       className="h-8 w-auto flex-shrink-0 brightness-0 invert mt-1"
                     />
                     <div className="flex-1 min-w-0">
@@ -657,9 +666,11 @@ export default function WindoorHomepage() {
               {/* Right Content - Image */}
               <div className="order-1 lg:order-2">
                 <div className="relative">
-                  <img
+                  <Image
                     src="/images/windoor-bathroom.jpeg"
                     alt="Interiores personalizados con acabados de máxima calidad"
+                    width={1200}
+                    height={600}
                     className="w-full h-[600px] object-cover rounded-2xl shadow-xl"
                   />
                   <div className="absolute bottom-6 left-6 right-6">

--- a/app/productos/ProductosClientPage.tsx
+++ b/app/productos/ProductosClientPage.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button"
 import { Calendar, ArrowRight, ChevronRight, Phone, MapPin, Mail, Instagram, Facebook, Menu } from "lucide-react"
 import Link from "next/link"
+import Image from "next/image"
 import { useState, useEffect } from "react"
 
 export default function ProductosClientPage() {
@@ -134,9 +135,11 @@ export default function ProductosClientPage() {
                     <div className="bg-white rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-500 overflow-hidden">
                       {/* Image */}
                       <div className="relative h-64 overflow-hidden">
-                        <img
+                        <Image
                           src={category.image || "/placeholder.svg"}
                           alt={category.title}
+                          width={800}
+                          height={600}
                           className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-110"
                         />
                         <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500"></div>

--- a/app/proyectos/ProyectosClientPage.tsx
+++ b/app/proyectos/ProyectosClientPage.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button"
 import { Play, X, ChevronRight, Eye, MessageSquare, Phone, MapPin, Mail, Instagram, Facebook, Menu } from "lucide-react"
 import Link from "next/link"
+import Image from "next/image"
 import { useState, useEffect } from "react"
 
 export default function ProyectosClientPage() {
@@ -165,9 +166,11 @@ export default function ProyectosClientPage() {
         return <video src={project.videoUrl} className="w-full h-full object-cover" controls autoPlay />
       default:
         return (
-          <img
+          <Image
             src={project.videoUrl || "/placeholder.svg"}
             alt={project.title}
+            width={800}
+            height={600}
             className="w-full h-full object-cover"
           />
         )
@@ -302,9 +305,11 @@ export default function ProyectosClientPage() {
                 {filteredProjects.map((project) => (
                   <div key={project.id} className="group cursor-pointer" onClick={() => openVideoModal(project)}>
                     <div className="relative overflow-hidden rounded-2xl bg-gray-100 aspect-[4/3]">
-                      <img
+                      <Image
                         src={project.thumbnail || "/placeholder.svg"}
                         alt={project.title}
+                        width={800}
+                        height={600}
                         className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-110"
                       />
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,7 +7,7 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
-    unoptimized: true,
+    domains: ["hebbkx1anhila5yf.public.blob.vercel-storage.com"],
   },
 }
 


### PR DESCRIPTION
## Summary
- replace HTML `<img>` elements with Next.js `<Image>` in landing, product, and project pages
- configure `next/image` for remote storage domain and remove unoptimized flag

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm build` *(fails: failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fd4b07b083279d8d615f61b2d977