### PR TITLE
Use span for site logo to keep hero heading unique

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -184,13 +184,13 @@ export default function WindoorHomepage() {
           <div className="flex items-center justify-between">
             {/* Logo */}
             <div className="flex items-center">
-              <h1
+              <span
                 className={`text-2xl font-bold tracking-wide transition-colors duration-500 ${
                   isScrolled ? "text-black" : "text-white"
                 }`}
               >
                 WINDOOR
-              </h1>
+              </span>
             </div>
 
             {/* Desktop Navigation */}


### PR DESCRIPTION
## Summary
- replace header logo h1 with span so the hero heading remains the page's only h1 while preserving existing styling

## Testing
- `pnpm lint` *(fails: asked for interactive ESLint setup)*
- `pnpm build` *(fails: Next.js font fetch error, build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a50087e5e48327ac80a51e38d11a0f