### PR TITLE
Use toast for reservation confirmation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,8 +16,10 @@ import {
 import Link from "next/link"
 import Image from "next/image"
 import { useState, useEffect } from "react"
+import { useToast } from "@/hooks/use-toast"
 
 export default function WindoorHomepage() {
+  const { toast } = useToast()
   const [isScrolled, setIsScrolled] = useState(false)
   const [showReservationModal, setShowReservationModal] = useState(false)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
@@ -95,7 +97,10 @@ export default function WindoorHomepage() {
 
   const handleReservation = () => {
     if (selectedDate && selectedTime) {
-      alert(`Reserva confirmada para el ${selectedDate} a las ${selectedTime}`)
+      toast({
+        title: "Reserva confirmada",
+        description: `Reserva confirmada para el ${selectedDate} a las ${selectedTime}`,
+      })
       setShowReservationModal(false)
       setSelectedDate("")
       setSelectedTime("")


### PR DESCRIPTION
## Summary
- import `useToast` hook in homepage
- show toast when a reservation is confirmed

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a50d1aedac832791ce389b7c1a9c52