### PR TITLE
feat: add toast support to layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react"
 import type { Metadata } from "next"
 import { Inter, Montserrat } from "next/font/google"
+import { Toaster } from "@/components/ui/toaster"
 import "./globals.css"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -61,7 +62,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="es">
-      <body className={`${inter.className} ${montserrat.variable}`}>{children}</body>
+      <body className={`${inter.className} ${montserrat.variable}`}>
+        {children}
+        <Toaster />
+      </body>
     </html>
   )
 }


### PR DESCRIPTION
## Summary
- add Toaster import in root layout
- render Toaster in layout body for toast notifications

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Failed to fetch `Inter` and `Montserrat` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a50ff439c883279f1dae3a33109af7