### PR TITLE
chore: enforce builds and fix date comparison

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,7 +52,7 @@ export default function WindoorHomepage() {
       date.setDate(startDate.getDate() + i)
 
       const isCurrentMonth = date.getMonth() === month
-      const isPast = date < today.setHours(0, 0, 0, 0)
+      const isPast = date.getTime() < today.setHours(0, 0, 0, 0)
       const isWeekend = date.getDay() === 0 || date.getDay() === 6
 
       days.push({

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,11 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   images: {
     domains: ["hebbkx1anhila5yf.public.blob.vercel-storage.com"],
   },


### PR DESCRIPTION
## Summary
- remove build ignore flags from Next.js config and define remote image domain
- fix date comparison in homepage calendar

## Testing
- `pnpm lint` *(fails: project lacks ESLint configuration)*
- `pnpm type-check` *(fails: command not found)*
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a50d225c788327979b1584c8c5dff5