### PR TITLE
feat: extract reusable contact form

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ import HeroSection from "@/components/home/HeroSection"
 import ServiciosSection from "@/components/home/ServiciosSection"
 import ContactoSection from "@/components/home/ContactoSection"
 import Header from "@/components/Header"
+import ContactForm from "@/components/ContactForm"
 
 export default function WindoorHomepage() {
   const { toast } = useToast()
@@ -315,76 +316,7 @@ export default function WindoorHomepage() {
                 {/* Updated contact form with all required fields and validations */}
                 <div className="mt-8 pt-6 border-t">
                   <h4 className="text-lg font-medium text-gray-900 mb-4">Tus Datos</h4>
-                  <form className="space-y-4">
-                    <div className="grid md:grid-cols-2 gap-4">
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">Nombre completo *</label>
-                        <input
-                          type="text"
-                          required
-                          placeholder="Tu nombre completo"
-                          className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">Teléfono *</label>
-                        <input
-                          type="tel"
-                          required
-                          pattern="[0-9]+"
-                          placeholder="Tu número de teléfono"
-                          className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                        />
-                      </div>
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">Email *</label>
-                      <input
-                        type="email"
-                        required
-                        placeholder="tu@email.com"
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      />
-                    </div>
-
-                    <div className="grid md:grid-cols-2 gap-4">
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">Tipo de cliente *</label>
-                        <select
-                          required
-                          className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                        >
-                          <option value="">Seleccionar tipo</option>
-                          <option value="particular">Particular</option>
-                          <option value="profesional">Profesional</option>
-                        </select>
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">Tipo de producto *</label>
-                        <select
-                          required
-                          className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                        >
-                          <option value="">Seleccionar producto</option>
-                          <option value="aberturas-pvc">Aberturas de PVC</option>
-                          <option value="vestidores-banos">Vestidores y baños</option>
-                          <option value="puertas-interior">Puertas de interior</option>
-                        </select>
-                      </div>
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        Mensaje / Medidas / Observaciones
-                      </label>
-                      <textarea
-                        rows={3}
-                        placeholder="Contanos sobre tu proyecto, medidas aproximadas, o cualquier detalle importante..."
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent resize-none"
-                      />
-                    </div>
-                  </form>
+                  <ContactForm className="space-y-4" includeDateTime={false} showSubmitButton={false} />
                 </div>
 
                 {/* Action Buttons */}

--- a/app/productos/aberturas-pvc/AberturasPVCClientPage.tsx
+++ b/app/productos/aberturas-pvc/AberturasPVCClientPage.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import { useState } from "react"
 import Header from "@/components/Header"
 import Footer from "@/components/Footer"
+import ContactForm from "@/components/ContactForm"
 
 export default function AberturasPVCClientPage() {
   const [showReservationModal, setShowReservationModal] = useState(false)
@@ -164,109 +165,7 @@ export default function AberturasPVCClientPage() {
             </div>
 
             <div className="bg-gray-50 rounded-3xl p-8 lg:p-12">
-              <form className="space-y-6">
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Nombre completo *</label>
-                    <input
-                      type="text"
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      placeholder="Tu nombre completo"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Teléfono *</label>
-                    <input
-                      type="tel"
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      placeholder="Tu número de teléfono"
-                    />
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">Email *</label>
-                  <input
-                    type="email"
-                    required
-                    className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    placeholder="tu@email.com"
-                  />
-                </div>
-
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Fecha preferida</label>
-                    <input
-                      type="date"
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Hora preferida</label>
-                    <select className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent">
-                      <option value="">Seleccionar hora</option>
-                      <option value="09:00">09:00</option>
-                      <option value="10:00">10:00</option>
-                      <option value="11:00">11:00</option>
-                      <option value="12:00">12:00</option>
-                      <option value="14:00">14:00</option>
-                      <option value="15:00">15:00</option>
-                      <option value="16:00">16:00</option>
-                      <option value="17:00">17:00</option>
-                    </select>
-                  </div>
-                </div>
-
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Tipo de cliente *</label>
-                    <select
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    >
-                      <option value="">Seleccionar tipo</option>
-                      <option value="particular">Particular</option>
-                      <option value="profesional">Profesional</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Tipo de producto *</label>
-                    <select
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    >
-                      <option value="">Seleccionar producto</option>
-                      <option value="aberturas-pvc">Aberturas de PVC</option>
-                      <option value="vestidores-banos">Vestidores y baños</option>
-                      <option value="puertas-interior">Puertas de interior</option>
-                    </select>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Mensaje / Medidas / Observaciones
-                  </label>
-                  <textarea
-                    rows={4}
-                    className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent resize-none"
-                    placeholder="Contanos sobre tu proyecto, medidas aproximadas, o cualquier detalle que consideres importante..."
-                  />
-                </div>
-
-                <div className="text-center pt-6">
-                  <Button
-                    type="submit"
-                    size="lg"
-                    className="bg-[#E6D5C3] hover:bg-[#DCC9B8] text-black font-semibold px-12 py-4 rounded-xl transition-all duration-300 hover:shadow-lg hover:scale-105"
-                  >
-                    Enviar Consulta
-                  </Button>
-                </div>
-              </form>
+              <ContactForm />
             </div>
           </div>
         </div>

--- a/app/productos/puertas-interior/PuertasInteriorClientPage.tsx
+++ b/app/productos/puertas-interior/PuertasInteriorClientPage.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import { useState } from "react"
 import Header from "@/components/Header"
 import Footer from "@/components/Footer"
+import ContactForm from "@/components/ContactForm"
 
 export default function PuertasInteriorClientPage() {
   const [showReservationModal, setShowReservationModal] = useState(false)
@@ -162,109 +163,7 @@ export default function PuertasInteriorClientPage() {
             </div>
 
             <div className="bg-gray-50 rounded-3xl p-8 lg:p-12">
-              <form className="space-y-6">
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Nombre completo *</label>
-                    <input
-                      type="text"
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      placeholder="Tu nombre completo"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Teléfono *</label>
-                    <input
-                      type="tel"
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      placeholder="Tu número de teléfono"
-                    />
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">Email *</label>
-                  <input
-                    type="email"
-                    required
-                    className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    placeholder="tu@email.com"
-                  />
-                </div>
-
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Fecha preferida</label>
-                    <input
-                      type="date"
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Hora preferida</label>
-                    <select className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent">
-                      <option value="">Seleccionar hora</option>
-                      <option value="09:00">09:00</option>
-                      <option value="10:00">10:00</option>
-                      <option value="11:00">11:00</option>
-                      <option value="12:00">12:00</option>
-                      <option value="14:00">14:00</option>
-                      <option value="15:00">15:00</option>
-                      <option value="16:00">16:00</option>
-                      <option value="17:00">17:00</option>
-                    </select>
-                  </div>
-                </div>
-
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Tipo de cliente *</label>
-                    <select
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    >
-                      <option value="">Seleccionar tipo</option>
-                      <option value="particular">Particular</option>
-                      <option value="profesional">Profesional</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Tipo de producto *</label>
-                    <select
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    >
-                      <option value="">Seleccionar producto</option>
-                      <option value="aberturas-pvc">Aberturas de PVC</option>
-                      <option value="vestidores-banos">Vestidores y baños</option>
-                      <option value="puertas-interior">Puertas de interior</option>
-                    </select>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Mensaje / Medidas / Observaciones
-                  </label>
-                  <textarea
-                    rows={4}
-                    className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent resize-none"
-                    placeholder="Contanos sobre tu proyecto, medidas aproximadas, o cualquier detalle que consideres importante..."
-                  />
-                </div>
-
-                <div className="text-center pt-6">
-                  <Button
-                    type="submit"
-                    size="lg"
-                    className="bg-[#E6D5C3] hover:bg-[#DCC9B8] text-black font-semibold px-12 py-4 rounded-xl transition-all duration-300 hover:shadow-lg hover:scale-105"
-                  >
-                    Enviar Consulta
-                  </Button>
-                </div>
-              </form>
+              <ContactForm />
             </div>
           </div>
         </div>

--- a/app/productos/vestidores-banos/VestidoresBanosClientPage.tsx
+++ b/app/productos/vestidores-banos/VestidoresBanosClientPage.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import { useState } from "react"
 import Header from "@/components/Header"
 import Footer from "@/components/Footer"
+import ContactForm from "@/components/ContactForm"
 
 export default function VestidoresBanosClientPage() {
   const [showReservationModal, setShowReservationModal] = useState(false)
@@ -162,109 +163,7 @@ export default function VestidoresBanosClientPage() {
             </div>
 
             <div className="bg-gray-50 rounded-3xl p-8 lg:p-12">
-              <form className="space-y-6">
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Nombre completo *</label>
-                    <input
-                      type="text"
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      placeholder="Tu nombre completo"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Teléfono *</label>
-                    <input
-                      type="tel"
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      placeholder="Tu número de teléfono"
-                    />
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">Email *</label>
-                  <input
-                    type="email"
-                    required
-                    className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    placeholder="tu@email.com"
-                  />
-                </div>
-
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Fecha preferida</label>
-                    <input
-                      type="date"
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Hora preferida</label>
-                    <select className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent">
-                      <option value="">Seleccionar hora</option>
-                      <option value="09:00">09:00</option>
-                      <option value="10:00">10:00</option>
-                      <option value="11:00">11:00</option>
-                      <option value="12:00">12:00</option>
-                      <option value="14:00">14:00</option>
-                      <option value="15:00">15:00</option>
-                      <option value="16:00">16:00</option>
-                      <option value="17:00">17:00</option>
-                    </select>
-                  </div>
-                </div>
-
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Tipo de cliente *</label>
-                    <select
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    >
-                      <option value="">Seleccionar tipo</option>
-                      <option value="particular">Particular</option>
-                      <option value="profesional">Profesional</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Tipo de producto *</label>
-                    <select
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                    >
-                      <option value="">Seleccionar producto</option>
-                      <option value="aberturas-pvc">Aberturas de PVC</option>
-                      <option value="vestidores-banos">Vestidores y baños</option>
-                      <option value="puertas-interior">Puertas de interior</option>
-                    </select>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Mensaje / Medidas / Observaciones
-                  </label>
-                  <textarea
-                    rows={4}
-                    className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent resize-none"
-                    placeholder="Contanos sobre tu proyecto, medidas aproximadas, o cualquier detalle que consideres importante..."
-                  />
-                </div>
-
-                <div className="text-center pt-6">
-                  <Button
-                    type="submit"
-                    size="lg"
-                    className="bg-[#E6D5C3] hover:bg-[#DCC9B8] text-black font-semibold px-12 py-4 rounded-xl transition-all duration-300 hover:shadow-lg hover:scale-105"
-                  >
-                    Enviar Consulta
-                  </Button>
-                </div>
-              </form>
+              <ContactForm />
             </div>
           </div>
         </div>

--- a/app/proyectos/ProyectosClientPage.tsx
+++ b/app/proyectos/ProyectosClientPage.tsx
@@ -7,6 +7,7 @@ import Image from "next/image"
 import { useState } from "react"
 import Header from "@/components/Header"
 import Footer from "@/components/Footer"
+import ContactForm from "@/components/ContactForm"
 
 export default function ProyectosClientPage() {
   const [activeFilter, setActiveFilter] = useState("Todas")
@@ -361,109 +362,7 @@ export default function ProyectosClientPage() {
               </div>
 
               <div className="bg-white rounded-3xl p-8 lg:p-12 shadow-lg">
-                <form className="space-y-6">
-                  <div className="grid md:grid-cols-2 gap-6">
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Nombre completo *</label>
-                      <input
-                        type="text"
-                        required
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                        placeholder="Tu nombre completo"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Teléfono *</label>
-                      <input
-                        type="tel"
-                        required
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                        placeholder="Tu número de teléfono"
-                      />
-                    </div>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Email *</label>
-                    <input
-                      type="email"
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      placeholder="tu@email.com"
-                    />
-                  </div>
-
-                  <div className="grid md:grid-cols-2 gap-6">
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Fecha preferida</label>
-                      <input
-                        type="date"
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Hora preferida</label>
-                      <select className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent">
-                        <option value="">Seleccionar hora</option>
-                        <option value="09:00">09:00</option>
-                        <option value="10:00">10:00</option>
-                        <option value="11:00">11:00</option>
-                        <option value="12:00">12:00</option>
-                        <option value="14:00">14:00</option>
-                        <option value="15:00">15:00</option>
-                        <option value="16:00">16:00</option>
-                        <option value="17:00">17:00</option>
-                      </select>
-                    </div>
-                  </div>
-
-                  <div className="grid md:grid-cols-2 gap-6">
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Tipo de cliente *</label>
-                      <select
-                        required
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      >
-                        <option value="">Seleccionar tipo</option>
-                        <option value="particular">Particular</option>
-                        <option value="profesional">Profesional</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Tipo de producto *</label>
-                      <select
-                        required
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      >
-                        <option value="">Seleccionar producto</option>
-                        <option value="aberturas-pvc">Aberturas de PVC</option>
-                        <option value="vestidores-banos">Vestidores y baños</option>
-                        <option value="puertas-interior">Puertas de interior</option>
-                      </select>
-                    </div>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Mensaje / Medidas / Observaciones
-                    </label>
-                    <textarea
-                      rows={4}
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent resize-none"
-                      placeholder="Contanos sobre tu proyecto, qué te gustó de los videos que viste, medidas aproximadas, o cualquier detalle importante..."
-                    />
-                  </div>
-
-                  <div className="text-center pt-6">
-                    <Button
-                      type="submit"
-                      size="lg"
-                      className="bg-[#E6D5C3] hover:bg-[#DCC9B8] text-black font-semibold px-12 py-4 rounded-xl transition-all duration-300 hover:shadow-lg hover:scale-105"
-                    >
-                      Enviar Consulta
-                    </Button>
-                  </div>
-                </form>
+                <ContactForm />
               </div>
             </div>
           </div>

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,0 +1,176 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { useToast } from "@/hooks/use-toast"
+import { cn } from "@/lib/utils"
+
+interface ContactFormProps {
+  className?: string
+  submitLabel?: string
+  showSubmitButton?: boolean
+  includeDateTime?: boolean
+  onSubmit?: (data: Record<string, FormDataEntryValue>) => void | Promise<void>
+}
+
+export default function ContactForm({
+  className,
+  submitLabel = "Enviar Consulta",
+  showSubmitButton = true,
+  includeDateTime = true,
+  onSubmit,
+}: ContactFormProps) {
+  const { toast } = useToast()
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const data = Object.fromEntries(formData.entries())
+
+    if (onSubmit) {
+      await onSubmit(data)
+    }
+
+    toast({
+      title: "Consulta enviada",
+      description: "Nos pondremos en contacto a la brevedad.",
+    })
+
+    event.currentTarget.reset()
+  }
+
+  return (
+    <form className={cn("space-y-6", className)} onSubmit={handleSubmit}>
+      <div className="grid md:grid-cols-2 gap-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Nombre completo *
+          </label>
+          <input
+            type="text"
+            name="name"
+            required
+            className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
+            placeholder="Tu nombre completo"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Teléfono *
+          </label>
+          <input
+            type="tel"
+            name="phone"
+            required
+            pattern="[0-9]+"
+            className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
+            placeholder="Tu número de teléfono"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Email *
+        </label>
+        <input
+          type="email"
+          name="email"
+          required
+          className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
+          placeholder="tu@email.com"
+        />
+      </div>
+
+      {includeDateTime && (
+        <div className="grid md:grid-cols-2 gap-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Fecha preferida
+            </label>
+            <input
+              type="date"
+              name="preferredDate"
+              className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Hora preferida
+            </label>
+            <select
+              name="preferredTime"
+              className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
+            >
+              <option value="">Seleccionar hora</option>
+              <option value="09:00">09:00</option>
+              <option value="10:00">10:00</option>
+              <option value="11:00">11:00</option>
+              <option value="12:00">12:00</option>
+              <option value="14:00">14:00</option>
+              <option value="15:00">15:00</option>
+              <option value="16:00">16:00</option>
+              <option value="17:00">17:00</option>
+            </select>
+          </div>
+        </div>
+      )}
+
+      <div className="grid md:grid-cols-2 gap-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Tipo de cliente *
+          </label>
+          <select
+            name="clientType"
+            required
+            className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
+          >
+            <option value="">Seleccionar tipo</option>
+            <option value="particular">Particular</option>
+            <option value="profesional">Profesional</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Tipo de producto *
+          </label>
+          <select
+            name="productType"
+            required
+            className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
+          >
+            <option value="">Seleccionar producto</option>
+            <option value="aberturas-pvc">Aberturas de PVC</option>
+            <option value="vestidores-banos">Vestidores y baños</option>
+            <option value="puertas-interior">Puertas de interior</option>
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Mensaje / Medidas / Observaciones
+        </label>
+        <textarea
+          name="message"
+          rows={4}
+          className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent resize-none"
+          placeholder="Contanos sobre tu proyecto, medidas aproximadas, o cualquier detalle que consideres importante..."
+        />
+      </div>
+
+      {showSubmitButton && (
+        <div className="text-center pt-6">
+          <Button
+            type="submit"
+            size="lg"
+            className="bg-[#E6D5C3] hover:bg-[#DCC9B8] text-black font-semibold px-12 py-4 rounded-xl transition-all duration-300 hover:shadow-lg hover:scale-105"
+          >
+            {submitLabel}
+          </Button>
+        </div>
+      )}
+    </form>
+  )
+}
+

--- a/components/home/ContactoSection.tsx
+++ b/components/home/ContactoSection.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button"
 import { Calendar, MapPin, Phone, Mail, Instagram, Facebook } from "lucide-react"
+import ContactForm from "@/components/ContactForm"
 import React from "react"
 
 interface ContactoSectionProps {
@@ -124,110 +125,7 @@ export default function ContactoSection({ onShowReservation }: ContactoSectionPr
               </div>
 
               <div className="bg-white rounded-3xl p-8 lg:p-12 shadow-lg">
-                <form className="space-y-6">
-                  <div className="grid md:grid-cols-2 gap-6">
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Nombre completo *</label>
-                      <input
-                        type="text"
-                        required
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                        placeholder="Tu nombre completo"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Teléfono *</label>
-                      <input
-                        type="tel"
-                        required
-                        pattern="[0-9]+"
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                        placeholder="Tu número de teléfono"
-                      />
-                    </div>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Email *</label>
-                    <input
-                      type="email"
-                      required
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      placeholder="tu@email.com"
-                    />
-                  </div>
-
-                  <div className="grid md:grid-cols-2 gap-6">
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Fecha preferida</label>
-                      <input
-                        type="date"
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Hora preferida</label>
-                      <select className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent">
-                        <option value="">Seleccionar hora</option>
-                        <option value="09:00">09:00</option>
-                        <option value="10:00">10:00</option>
-                        <option value="11:00">11:00</option>
-                        <option value="12:00">12:00</option>
-                        <option value="14:00">14:00</option>
-                        <option value="15:00">15:00</option>
-                        <option value="16:00">16:00</option>
-                        <option value="17:00">17:00</option>
-                      </select>
-                    </div>
-                  </div>
-
-                  <div className="grid md:grid-cols-2 gap-6">
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Tipo de cliente *</label>
-                      <select
-                        required
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      >
-                        <option value="">Seleccionar tipo</option>
-                        <option value="particular">Particular</option>
-                        <option value="profesional">Profesional</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">Tipo de producto *</label>
-                      <select
-                        required
-                        className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent"
-                      >
-                        <option value="">Seleccionar producto</option>
-                        <option value="aberturas-pvc">Aberturas de PVC</option>
-                        <option value="vestidores-banos">Vestidores y baños</option>
-                        <option value="puertas-interior">Puertas de interior</option>
-                      </select>
-                    </div>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Mensaje / Medidas / Observaciones
-                    </label>
-                    <textarea
-                      rows={4}
-                      className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#E6D5C3] focus:border-transparent resize-none"
-                      placeholder="Contanos sobre tu proyecto, medidas aproximadas, o cualquier detalle que consideres importante..."
-                    />
-                  </div>
-
-                  <div className="text-center pt-6">
-                    <Button
-                      type="submit"
-                      size="lg"
-                      className="bg-[#E6D5C3] hover:bg-[#DCC9B8] text-black font-semibold px-12 py-4 rounded-xl transition-all duration-300 hover:shadow-lg hover:scale-110"
-                    >
-                      Enviar Consulta
-                    </Button>
-                  </div>
-                </form>
+                <ContactForm />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- create reusable `ContactForm` component with validation and toast submission handling
- replace duplicated forms in home, product, project pages and landing modal with `ContactForm`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompt to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68a672ab14e883279844513b57270dc5