### PR TITLE
feat: add scroll position hook

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react"
 import Image from "next/image"
 import { useState, useEffect } from "react"
+import { useScrollPosition } from "@/hooks/use-scroll-position"
 import { useToast } from "@/hooks/use-toast"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
@@ -29,6 +30,8 @@ export default function WindoorHomepage() {
   const [isMounted, setIsMounted] = useState(false)
   const isMobile = useIsMobile()
   const [isBadgeOpen, setIsBadgeOpen] = useState(false)
+  const scrollY = useScrollPosition()
+  const shouldShowBadge = showDeCasasBadge && scrollY < 100
 
   useEffect(() => {
     setIsMounted(true)
@@ -116,7 +119,7 @@ export default function WindoorHomepage() {
         <div />
       ) : (
         <>
-          {showDeCasasBadge && (
+          {shouldShowBadge && (
             <div className="fixed md:top-20 md:right-6 bottom-6 right-4 z-40">
               <div className="relative group">
                 <div

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,27 +1,18 @@
 "use client"
 
 import Link from "next/link"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { Phone, MapPin } from "lucide-react"
+import { useScrollPosition } from "@/hooks/use-scroll-position"
 
 interface HeaderProps {
   active?: "inicio" | "productos" | "nosotros" | "proyectos" | "contacto"
 }
 
 export default function Header({ active }: HeaderProps) {
-  const [isScrolled, setIsScrolled] = useState(active !== "inicio")
+  const scrollY = useScrollPosition()
+  const isScrolled = active !== "inicio" || scrollY > 50
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-
-  useEffect(() => {
-    if (active !== "inicio") return
-
-    const handleScroll = () => {
-      setIsScrolled(window.scrollY > 50)
-    }
-
-    window.addEventListener("scroll", handleScroll)
-    return () => window.removeEventListener("scroll", handleScroll)
-  }, [active])
 
   const textColor = isScrolled ? "text-black" : "text-white"
   const linkClasses = (id: HeaderProps["active"], color: string) =>

--- a/hooks/use-scroll-position.ts
+++ b/hooks/use-scroll-position.ts
@@ -1,0 +1,32 @@
+import * as React from "react"
+
+export function useScrollPosition() {
+  const [scrollY, setScrollY] = React.useState(0)
+
+  React.useEffect(() => {
+    let animationFrame: number | null = null
+
+    const updateScroll = () => {
+      setScrollY(window.scrollY)
+      animationFrame = null
+    }
+
+    const handleScroll = () => {
+      if (animationFrame === null) {
+        animationFrame = window.requestAnimationFrame(updateScroll)
+      }
+    }
+
+    handleScroll()
+    window.addEventListener("scroll", handleScroll, { passive: true })
+
+    return () => {
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame)
+      }
+      window.removeEventListener("scroll", handleScroll)
+    }
+  }, [])
+
+  return scrollY
+}


### PR DESCRIPTION
## Summary
- add `useScrollPosition` hook to track window scroll
- refactor header and homepage to use the new hook

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a6741d04488327830b78b4c56106a2